### PR TITLE
Enabled enableExternalDirectory

### DIFF
--- a/Version 1.1/Archon Version/manifest.json
+++ b/Version 1.1/Archon Version/manifest.json
@@ -8,7 +8,7 @@
 		"apkList": [
 			"custom-android-release-1400197.apk"
 		],
-		"enableExternalDirectory": false,
+		"enableExternalDirectory": true,
 		"formFactor": "phone",
 		"name": "Skype For Chrome",
 		"orientation": "portrait",


### PR DESCRIPTION
The enableExternalDirectory setting allows to save received files into host filesystem. Without this setting, users can receive files, but are unable to access them.
